### PR TITLE
Make ReflectAvroSerde thread-safe

### DIFF
--- a/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroDeserializer.java
+++ b/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroDeserializer.java
@@ -58,10 +58,9 @@ public class ReflectAvroDeserializer<T> implements Deserializer<T> {
                 @SuppressWarnings("unchecked")
                 public DatumReader<T> load(final Integer id) throws IOException, RestClientException {
                     final Schema schema = ReflectAvroDeserializer.this.schemaRegistryClient.getById(id);
-                    return (DatumReader<T>) ReflectAvroDeserializer.this.data
-                            .createDatumReader(schema,
-                                    ReflectAvroDeserializer.this.readerSchema == null ? schema
-                                            : ReflectAvroDeserializer.this.readerSchema);
+                    final Schema reader = ReflectAvroDeserializer.this.readerSchema == null ? schema
+                            : ReflectAvroDeserializer.this.readerSchema;
+                    return (DatumReader<T>) ReflectAvroDeserializer.this.data.createDatumReader(schema, reader);
                 }
             });
 

--- a/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroDeserializer.java
+++ b/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroDeserializer.java
@@ -34,8 +34,8 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.avro.Schema;
@@ -48,50 +48,50 @@ import org.apache.kafka.common.serialization.Deserializer;
 
 public class ReflectAvroDeserializer<T> implements Deserializer<T> {
     protected static final byte MAGIC_BYTE = 0;
-    private final Map<Integer, DatumReader<T>> readerCache = new HashMap<>();
+    private final Map<Integer, DatumReader<T>> readerCache = new ConcurrentHashMap<>();
     @Getter(AccessLevel.PACKAGE)
     @VisibleForTesting
     private final Schema readerSchema;
-    private Reflect2Data data = new Reflect2Data();
+    private final Reflect2Data data = new Reflect2Data();
     private SchemaRegistryClient schemaRegistryClient;
-    private DecoderFactory decoderFactory = DecoderFactory.get();
-    private BinaryDecoder oldDecoder;
+    private final DecoderFactory decoderFactory = DecoderFactory.get();
+    private BinaryDecoder oldDecoder = null;
 
     public ReflectAvroDeserializer() {
         this(null, (Type) null);
     }
 
-    public ReflectAvroDeserializer(Schema schema) {
+    public ReflectAvroDeserializer(final Schema schema) {
         this(null, schema);
     }
 
-    public ReflectAvroDeserializer(Type target) {
+    public ReflectAvroDeserializer(final Type target) {
         this(null, target);
     }
 
-    public ReflectAvroDeserializer(SchemaRegistryClient client) {
+    public ReflectAvroDeserializer(final SchemaRegistryClient client) {
         this(client, (Type) null);
     }
 
-    public ReflectAvroDeserializer(SchemaRegistryClient client, Schema schema) {
+    public ReflectAvroDeserializer(final SchemaRegistryClient client, final Schema schema) {
         this.schemaRegistryClient = client;
         this.readerSchema = schema;
     }
 
-    public ReflectAvroDeserializer(SchemaRegistryClient client, Type target) {
+    public ReflectAvroDeserializer(final SchemaRegistryClient client, final Type target) {
         this.schemaRegistryClient = client;
         if (target == null) {
-            target = new TypeToken<T>(getClass()) {}.getType();
-            this.readerSchema = target instanceof TypeVariable ? null : Reflect2Data.get().getSchema(target);
+            final Type type = new TypeToken<T>(this.getClass()) {}.getType();
+            this.readerSchema = type instanceof TypeVariable ? null : Reflect2Data.get().getSchema(type);
         } else {
             this.readerSchema = Reflect2Data.get().getSchema(target);
         }
     }
 
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
         if (this.schemaRegistryClient == null) {
-            var config = new KafkaAvroDeserializerConfig(configs);
+            final var config = new KafkaAvroDeserializerConfig(configs);
             this.schemaRegistryClient =
                     new CachedSchemaRegistryClient(config.getSchemaRegistryUrls(), config.getMaxSchemasPerSubject(),
                             config.originalsWithPrefix(""));
@@ -99,31 +99,31 @@ public class ReflectAvroDeserializer<T> implements Deserializer<T> {
     }
 
     @Override
-    public T deserialize(String topic, byte[] data) {
+    public T deserialize(final String topic, final byte[] data) {
         if (data == null) {
             return null;
         }
-        int id = -1;
+
+        final ByteBuffer buffer = ByteBuffer.wrap(data);
+
+        if (buffer.get() != MAGIC_BYTE) {
+            throw new SerializationException("Error deserializing Avro message, Unknown magic byte!");
+        }
+
+        final int id = buffer.getInt();
         try {
-            ByteBuffer buffer = ByteBuffer.wrap(data);
+            final Schema schema = this.schemaRegistryClient.getById(id);
 
-            if (buffer.get() != MAGIC_BYTE) {
-                throw new SerializationException("Unknown magic byte!");
-            }
-
-            id = buffer.getInt();
-            Schema schema = schemaRegistryClient.getById(id);
-
-            int length = buffer.remaining();
-            int start = buffer.position();
-            DatumReader<T> reader = readerCache.computeIfAbsent(id, key ->
-                    this.data.createDatumReader(schema, readerSchema == null ? schema : readerSchema));
+            final int length = buffer.remaining();
+            final int start = buffer.position();
+            final DatumReader<T> reader = this.readerCache.computeIfAbsent(id, key ->
+                    this.data.createDatumReader(schema, this.readerSchema == null ? schema : this.readerSchema));
             return reader.read(null,
-                    oldDecoder = decoderFactory.binaryDecoder(buffer.array(), start, length, oldDecoder));
-        } catch (IOException | RuntimeException e) {
+                    this.oldDecoder = this.decoderFactory.binaryDecoder(buffer.array(), start, length, this.oldDecoder));
+        } catch (final IOException | RuntimeException e) {
             // avro deserialization may throw AvroRuntimeException, NullPointerException, etc
             throw new SerializationException("Error deserializing Avro message for id " + id, e);
-        } catch (RestClientException e) {
+        } catch (final RestClientException e) {
             throw new SerializationException("Error retrieving Avro schema for id " + id, e);
         }
     }

--- a/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroSerializer.java
+++ b/kafka-streams-reflect-avro-serde/src/main/java/com/bakdata/kafka_streams/reflect_avro_serde/ReflectAvroSerializer.java
@@ -37,8 +37,8 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.apache.avro.Schema;
@@ -50,95 +50,99 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Serializer;
 
 public class ReflectAvroSerializer<T> implements Serializer<T> {
-    private final Map<Integer, DatumWriter<T>> writerCache = new HashMap<>();
+    private final Map<Integer, DatumWriter<T>> writerCache = new ConcurrentHashMap<>();
     @Getter(AccessLevel.PACKAGE)
     @VisibleForTesting
     private final Schema writerSchema;
     private SchemaRegistryClient schemaRegistryClient;
-    private Reflect2Data data = new Reflect2Data();
+    private final Reflect2Data data = new Reflect2Data();
     private boolean autoRegisterSchema = true;
-    private EncoderFactory encoderFactory = EncoderFactory.get();
-    private BinaryEncoder oldEncoder;
-    private MyAbstractKafkaAvroSerDe serde = new MyAbstractKafkaAvroSerDe();
-    private boolean isKey;
+    private final EncoderFactory encoderFactory = EncoderFactory.get();
+    private BinaryEncoder oldEncoder = null;
+    private final MyAbstractKafkaAvroSerDe serde = new MyAbstractKafkaAvroSerDe();
+    private boolean isKey = false;
 
     public ReflectAvroSerializer() {
         this(null, (Type) null);
     }
 
-    public ReflectAvroSerializer(Schema schema) {
+    public ReflectAvroSerializer(final Schema schema) {
         this(null, schema);
     }
 
-    public ReflectAvroSerializer(Type target) {
+    public ReflectAvroSerializer(final Type target) {
         this(null, target);
     }
 
-    public ReflectAvroSerializer(SchemaRegistryClient client) {
+    public ReflectAvroSerializer(final SchemaRegistryClient client) {
         this(client, (Type) null);
     }
 
-    public ReflectAvroSerializer(SchemaRegistryClient client, Schema schema) {
-        this.schemaRegistryClient = schemaRegistryClient;
+    public ReflectAvroSerializer(final SchemaRegistryClient client, final Schema schema) {
+        this.schemaRegistryClient = client;
         this.writerSchema = schema;
     }
 
-    public ReflectAvroSerializer(SchemaRegistryClient client, Type target) {
-        this.schemaRegistryClient = schemaRegistryClient;
+    public ReflectAvroSerializer(final SchemaRegistryClient client, final Type target) {
+        this.schemaRegistryClient = client;
         if (target == null) {
-            target = new TypeToken<T>(getClass()) {}.getType();
-            this.writerSchema = target instanceof TypeVariable ? null : Reflect2Data.get().getSchema(target);
+            final Type type = new TypeToken<T>(this.getClass()) {}.getType();
+            this.writerSchema = type instanceof TypeVariable ? null : Reflect2Data.get().getSchema(type);
         } else {
             this.writerSchema = Reflect2Data.get().getSchema(target);
         }
     }
 
     @Override
-    public void configure(Map<String, ?> configs, boolean isKey) {
+    public void configure(final Map<String, ?> configs, final boolean isKey) {
         final KafkaAvroSerializerConfig config = new KafkaAvroSerializerConfig(configs);
-        serde.configureClientProperties(config);
+        this.serde.configureClientProperties(config);
         this.isKey = isKey;
         this.autoRegisterSchema = config.autoRegisterSchema();
-        Map<String, Object> originals = config.originalsWithPrefix("");
+        final Map<String, Object> originals = config.originalsWithPrefix("");
         if (this.schemaRegistryClient == null) {
-            this.schemaRegistryClient =
-                    new CachedSchemaRegistryClient(config.getSchemaRegistryUrls(), config.getMaxSchemasPerSubject(),
-                            originals);
+            this.schemaRegistryClient = new CachedSchemaRegistryClient(config.getSchemaRegistryUrls(),
+                    config.getMaxSchemasPerSubject(), originals);
         }
     }
 
     @Override
-    public byte[] serialize(String topic, T data) {
+    public byte[] serialize(final String topic, final T data) {
         if (data == null) {
             return null;
         }
 
         int id = -1;
         try {
-            final Schema schema = writerSchema != null ? writerSchema : this.data.getSchema(data);
-            String subject = serde.getSubjectName(topic, isKey, data, schema);
-            if (this.autoRegisterSchema) {
-                id = this.schemaRegistryClient.register(subject, schema);
-            } else {
-                id = this.schemaRegistryClient.getId(subject, schema);
-            }
+            final Schema schema = this.writerSchema != null ? this.writerSchema : this.data.getSchema(data);
+            final String subject = this.serde.getSubjectName(topic, this.isKey, data, schema);
+            id = this.storeOrRetrieveSchema(subject, schema);
 
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            final ByteArrayOutputStream out = new ByteArrayOutputStream();
             out.write(0);
             out.write(ByteBuffer.allocate(4).putInt(id).array());
-            BinaryEncoder encoder = oldEncoder = this.encoderFactory.directBinaryEncoder(out, oldEncoder);
-            DatumWriter<T> writer = writerCache.computeIfAbsent(id, key -> this.data.createDatumWriter(schema));
+            final BinaryEncoder encoder = this.oldEncoder = this.encoderFactory.directBinaryEncoder(out, this.oldEncoder);
+            final DatumWriter<T> writer = this.writerCache.computeIfAbsent(id, key -> this.data.createDatumWriter(schema));
 
-            ((DatumWriter) writer).write(data, encoder);
+            writer.write(data, encoder);
             encoder.flush();
 
             return out.toByteArray();
-        } catch (IOException | RuntimeException e) {
+        } catch (final IOException | RuntimeException e) {
             // avro deserialization may throw AvroRuntimeException, NullPointerException, etc
             throw new SerializationException("Error serializing Avro message for id " + id, e);
-        } catch (RestClientException e) {
+        } catch (final RestClientException e) {
             throw new SerializationException("Error retrieving Avro schema for id " + id, e);
         }
+    }
+
+    private int storeOrRetrieveSchema(final String subject, final Schema schema)
+            throws IOException, RestClientException {
+        if (this.autoRegisterSchema) {
+            return this.schemaRegistryClient.register(subject, schema);
+        }
+
+        return this.schemaRegistryClient.getId(subject, schema);
     }
 
     @Override


### PR DESCRIPTION
When used in multiple threads concurrently, ReflectAvroDeserializer may throw an exception due to concurrent writes to its cache. This PR replaces the old HashMap with a thread-safe cache implementation provided by Guava.

```
org.apache.kafka.common.errors.SerializationException: Error deserializing Avro message for id 31
Caused by: java.util.ConcurrentModificationException
	at java.base/java.util.HashMap.computeIfAbsent(HashMap.java:1134)
	at com.bakdata.kafka_streams.reflect_avro_serde.ReflectAvroDeserializer.deserialize(ReflectAvroDeserializer.java:119)
	at org.apache.kafka.common.serialization.Deserializer.deserialize(Deserializer.java:60)
	at org.apache.kafka.streams.processor.internals.SourceNode.deserializeKey(SourceNode.java:56)
	at org.apache.kafka.streams.processor.internals.RecordDeserializer.deserialize(RecordDeserializer.java:65)
	at org.apache.kafka.streams.processor.internals.RecordQueue.updateHead(RecordQueue.java:158)
	at org.apache.kafka.streams.processor.internals.RecordQueue.addRawRecords(RecordQueue.java:100)
	at org.apache.kafka.streams.processor.internals.PartitionGroup.addRawRecords(PartitionGroup.java:136)
	at org.apache.kafka.streams.processor.internals.StreamTask.addRecords(StreamTask.java:746)
	at org.apache.kafka.streams.processor.internals.StreamThread.addRecordsToTasks(StreamThread.java:1023)
	at org.apache.kafka.streams.processor.internals.StreamThread.runOnce(StreamThread.java:861)
	at org.apache.kafka.streams.processor.internals.StreamThread.runLoop(StreamThread.java:805)
	at org.apache.kafka.streams.processor.internals.StreamThread.run(StreamThread.java:774)
```